### PR TITLE
DRAFT: Highlight duplicate ECB ciphertext blocks and show ❌ when patterns detected

### DIFF
--- a/assignment2/symmetric_lab/app.js
+++ b/assignment2/symmetric_lab/app.js
@@ -753,17 +753,48 @@ document.addEventListener('DOMContentLoaded', function() {
             document.getElementById('ctr-result').innerHTML = 
                 `<div class="cipher-hex">${ctrEncrypted.ciphertext.toString()}</div>`;
             
-            // Analyze patterns
-            analyzePatterns(plaintext, ecbEncrypted.ciphertext.toString(), 'ecb-analysis');
-            analyzePatterns(plaintext, cbcEncrypted.ciphertext.toString(), 'cbc-analysis');
-            analyzePatterns(plaintext, ctrEncrypted.ciphertext.toString(), 'ctr-analysis');
+
+            // Re-render ECB with highlighted duplicate blocks
+            const ecbHex = ecbEncrypted.ciphertext.toString();
+            document.getElementById('ecb-result').innerHTML =
+                `<div class="cipher-hex">${renderCipherBlocks(ecbHex, true)}</div>`;
+
+            // Analyze patterns (show red X for duplicates, green check for unique)
+            analyzePatterns(ecbHex, 'ecb-analysis');
+            analyzePatterns(cbcEncrypted.ciphertext.toString(), 'cbc-analysis');
+            analyzePatterns(ctrEncrypted.ciphertext.toString(), 'ctr-analysis');
             
         } catch (error) {
             alert('Comparison error: ' + error.message);
         }
     }
 
-    function analyzePatterns(plaintext, ciphertext, elementId) {
+
+    function renderCipherBlocks(hex, highlightDuplicates) {
+        const blockSize = 32; // 16 bytes in hex
+        const blocks = [];
+        for (let i = 0; i < hex.length; i += blockSize) {
+            blocks.push(hex.slice(i, i + blockSize));
+        }
+
+        let dupMap = {};
+        if (highlightDuplicates) {
+            const counts = {};
+            blocks.forEach(b => counts[b] = (counts[b] || 0) + 1);
+            Object.keys(counts).forEach(b => {
+                if (counts[b] > 1) dupMap[b] = true;
+            });
+        }
+
+        return blocks.map((b) => {
+            if (highlightDuplicates && dupMap[b]) {
+                return `<span class="cipher-block dup-block" title="Duplicate block">✖ ${b}</span>`;
+            }
+            return `<span class="cipher-block">${b}</span>`;
+        }).join(' ');
+    }
+
+    function analyzePatterns(ciphertext, elementId) {
         const element = document.getElementById(elementId);
         if (element) {
             // Simple pattern analysis
@@ -776,7 +807,7 @@ document.addEventListener('DOMContentLoaded', function() {
             const patternPreserved = uniqueBlocks.size < blocks.length;
             
             if (patternPreserved) {
-                element.innerHTML = '<span class="danger-text">⚠️ Patterns detected! Identical blocks found.</span>';
+                element.innerHTML = '<span class="danger-text">❌ Patterns detected! Identical blocks found.</span>';
             } else {
                 element.innerHTML = '<span class="success-text">✅ No patterns detected. All blocks unique.</span>';
             }

--- a/assignment2/symmetric_lab/index.html
+++ b/assignment2/symmetric_lab/index.html
@@ -423,7 +423,7 @@
                     <div class="exercise">
                         <div class="input-group">
                             <label for="pattern-input">Plaintext with Repeating Pattern:</label>
-                            <input type="text" id="pattern-input" value="HELLO WORLD! HELLO WORLD! HELLO WORLD! HELLO WORLD!" placeholder="Enter text with repeating patterns">
+                            <input type="text" id="pattern-input" value="YELLOW SUBMARINEYELLOW SUBMARINEYELLOW SUBMARINEYELLOW SUBMARINE" placeholder="Enter text with repeating patterns">
                             <button id="compare-modes" class="primary-button">Compare All Modes</button>
                         </div>
                         

--- a/assignment2/symmetric_lab/style.css
+++ b/assignment2/symmetric_lab/style.css
@@ -708,6 +708,23 @@ h4 {
   line-height: 1.4;
 }
 
+.cipher-block {
+  display: inline-block;
+  padding: 2px 4px;
+  margin: 0 2px 4px 0;
+  border-radius: 3px;
+  background: #fff;
+  border: 1px solid #e9ecef;
+}
+
+.dup-block {
+  color: var(--color-danger);
+  border-color: var(--color-danger);
+  background: #ffe5e9;
+  font-weight: 700;
+}
+
+
 .pattern-analysis {
   padding: 10px;
   border-radius: 5px;


### PR DESCRIPTION
Summary
- Improves the Application tab in assignment2/symmetric_lab to better demonstrate ECB weaknesses.
- Highlights duplicate 16-byte ciphertext blocks for ECB with a red background and ✖ marker.
- Shows ❌ Patterns detected! message when duplicates exist; ✅ when all blocks are unique.

Changes
- index.html: default pattern-input set to repeating "YELLOW SUBMARINE" to ensure repeating 16-byte blocks for ECB demo.
- app.js:
  - Added renderCipherBlocks(hex, highlightDuplicates) to split ciphertext into 16-byte (32 hex) blocks and optionally highlight duplicates.
  - Wired ECB result rendering to use renderCipherBlocks with duplicate highlighting enabled.
  - analyzePatterns now reports ❌ for duplicates; ✅ for unique.
- style.css: added .cipher-block and .dup-block styles; fixed CSS block closure.

Behavior
- ECB: ciphertext output renders as grouped blocks; duplicate blocks are highlighted with a red background and ✖ prefix. Analysis shows red ❌ message.
- CBC/CTR: continue to render raw hex for now (can wire to block rendering without highlighting in a follow-up if desired).

Testing
- start-lab.sh (Python http.server) used locally on port 12000. Manual verification recommended:
  1) Open Application tab
  2) Use default plaintext (repeating YELLOW SUBMARINE)
  3) Click "Compare All Modes"
  4) ECB result should show highlighted duplicate blocks; CBC/CTR should not highlight; analysis text should match.

Notes
- Kept changes minimal and educational; no functional breakages expected. If you prefer CTR/CBC to also use the block renderer (without highlighting), I can update compareEncryptionModes accordingly.

Co-authored-by: openhands <openhands@all-hands.dev>

@jacks4ever can click here to [continue refining the PR](https://app.all-hands.dev/conversations/bf1721ae7f04467ea70a197fa9770508)